### PR TITLE
zc.queue should be less than 2.0.0a1 to not pull in ZODB4 and friends.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,6 +2,12 @@ History
 =======
 
 
+0.7.4 (Unreleased)
+------------------
+
+- zc.queue should be less than 2.0.0a1 to not pull in ZODB4 and friends.
+  [ale-rt]
+
 0.7.3 (2015-08-31)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'zope.app.keyreference==3.6.1',
         'zope.app.catalog',
         'zope.app.i18n',
-        'zc.queue',
+        'zc.queue<2.0.0a1',
         'zc.lockfile',
         'plone.z3cform>=0.5.1',
     ],


### PR DESCRIPTION
At the moment the latest good version for zc.queue is 1.3 because 2.0.0a1 depends on ZODB4.

This is not pinned in standard plone cfgs (e.g. http://dist.plone.org/release/4.3.6/versions.cfg), so we should limit this in the package setup.py.
