### PR TITLE
do not require channel.description

### DIFF
--- a/collective/singing/interfaces.py
+++ b/collective/singing/interfaces.py
@@ -219,7 +219,8 @@ class IChannel(interface.Interface):
         )
 
     description = schema.Text(
-        title=_(u"Description")
+        title=_(u"Description"),
+        required=False
         )
 
     subscribeable = schema.Bool(

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ History
 0.7.5 (Unreleased)
 ------------------
 
+- make channel description an optional field so users can leave it empty
+  if no description is needed
+  [fRiSi]
+
 - Update README file to use github repo instead of svn.
   [ivanteoh]
 


### PR DESCRIPTION
i'd like to make the description field optional so people can leave it blank in http://nohost/plone/portal_newsletters/channels/<channelname>/@@index_html

* any objections on making description an optional field?
* any objections in implementing it this way?

@ivanteoh, @saily, @ale-rt  - i'm mentioning you guys as you last contributed to s&d ;-)