### PR TITLE
WIP allow to mark subscriptions as 'unsubscribed'

### DIFF
--- a/collective/singing/browser/subscribe.py
+++ b/collective/singing/browser/subscribe.py
@@ -177,7 +177,8 @@ class Subscribe(wizard.Wizard):
         secret = self._secret(comp_data, self.request)
         metadata = dict(format=self.format(),
                         date=datetime.datetime.now(),
-                        pending=True)
+                        pending=True,
+                        unsubscribed=None)
 
         # We assume here that the language of the request is the
         # desired language of the subscription:
@@ -213,6 +214,7 @@ class Subscribe(wizard.Wizard):
 
 class Unsubscribe(utils.OverridableTemplate,
                   zope.publisher.browser.BrowserView):
+
     def index(self):
         return u"<p>You have been unsubscribed.</p>"
 

--- a/collective/singing/browser/subscribe.txt
+++ b/collective/singing/browser/subscribe.txt
@@ -64,13 +64,13 @@ subscriptions (for the same format):
   ...
   ...     def secret(self, data):
   ...         return data['email']
-  ... 
+  ...
   ...     def render_confirmation(self, subscription):
   ...         email = subscription.composer_data['email']
   ...         return Message(
   ...             u"This is a message to %s to confirm their subscription." %
   ...             (email,))
-  ... 
+  ...
   ...     def render_forgot_secret(self, subscription):
   ...         email = subscription.composer_data['email']
   ...         return Message(
@@ -97,10 +97,10 @@ to send:
   >>> class Dispatch(object):
   ...     interface.implements(interfaces.IDispatch)
   ...     component.adapts(unicode)
-  ... 
+  ...
   ...     def __init__(self, message):
   ...         self.message = message
-  ... 
+  ...
   ...     def __call__(self):
   ...         print "This is your dispatcher speaking: ",
   ...         print self.message
@@ -204,7 +204,8 @@ We're now subscribed to the channel:
     collectordata: {'colour': 'red'},
     and metadata: {'date': datetime.datetime(...),
                    'format': 'html',
-                   'pending': True}>]
+                   'pending': True,
+                   'unsubscribed': None}>]
 
   >>> 'Thanks for your subscription' in html
   True
@@ -228,12 +229,12 @@ define such an adapter:
   >>> class MyUserPreferredLanguages(object):
   ...     component.adapts(IRequest)
   ...     interface.implements(IUserPreferredLanguages)
-  ... 
+  ...
   ...     def __init__(self, request):
   ...         pass
   ...     def getPreferredLanguages(self):
   ...         return ['ba', 'bm']
-  ... 
+  ...
   >>> component.provideAdapter(MyUserPreferredLanguages)
 
   >>> request.form['composer.widgets.email'] = u'hanno@testingunderground.com'
@@ -258,7 +259,7 @@ we'll define another composer:
   >>> __builtins__['PlainTextEmailComposer'] = PlainTextEmailComposer
 
   >>> channel.composers['plaintext'] = PlainTextEmailComposer()
-    
+
   >>> request = TestRequest()
   >>> subscribe = Subscribe(channel, request)
   >>> html = subscribe()
@@ -313,7 +314,8 @@ pending:
   >>> pprint(dict(html.metadata)) # doctest: +ELLIPSIS
   {'date': datetime.datetime(...),
    'format': 'html',
-   'pending': True}
+   'pending': True,
+   'unsubscribed': None}
 
 Forgot secret
 -------------

--- a/collective/singing/scheduler.py
+++ b/collective/singing/scheduler.py
@@ -66,7 +66,10 @@ class MessageAssemble(object):
             override_vars = {}
 
         subscription_metadata = subscription.metadata
-        if subscription_metadata.get('pending'):
+        pending = subscription_metadata.get('pending')
+        unsubscribed = (
+            subscription_metadata.get('unsubscribed', None) is not None)
+        if (pending or unsubscribed):
             return None
 
         # Collect items for subscription
@@ -340,5 +343,6 @@ class TimedScheduler(persistent.Persistent, AbstractPeriodicScheduler):
 
     def __ne__(self, other):
         return not self == other
+
 
 schedulers = (WeeklyScheduler, DailyScheduler, ManualScheduler, TimedScheduler)

--- a/collective/singing/scheduler.txt
+++ b/collective/singing/scheduler.txt
@@ -16,7 +16,7 @@ implementations:
   True
   >>> verify.verifyClass(interfaces.IScheduler, scheduler.ManualScheduler)
   True
-  
+
 Schedulers have an overwritten ``__eq__`` special method for comparison:
 
   >>> scheduler.DailyScheduler() == scheduler.DailyScheduler()
@@ -30,7 +30,7 @@ Schedulers implement a ``tick`` method that'll call
   >>> from zope.publisher.browser import TestRequest
   >>> request = TestRequest()
 
-Our request needs to be annotatable. 
+Our request needs to be annotatable.
 
   >>> from zope.annotation.attribute import AttributeAnnotations
   >>> from zope import component
@@ -90,10 +90,10 @@ happens:
   >>> class MessageAssemble(object):
   ...     interface.implements(interfaces.IMessageAssemble)
   ...     component.adapts(interfaces.IChannel)
-  ... 
+  ...
   ...     def __init__(self, channel):
   ...         self.channel = channel
-  ... 
+  ...
   ...     def __call__(self, request, items=(), use_collector=True, override_vars=None):
   ...         if override_vars is None: override_vars={}
   ...         print "Sending out %r." % (items,)
@@ -167,7 +167,7 @@ At this point, we'll provide our own ``IChannel``, ``IComposer`` and
 
   >>> class Composer(object):
   ...     def render(self, subscription, items=(), override_vars=None):
-  ...	      if override_vars is None: override_vars={}
+  ...         if override_vars is None: override_vars={}
   ...         formatted = tuple([item[0] for item in items])
   ...         print "Rendering message with %r for %r" % (
   ...             formatted, subscription)
@@ -192,6 +192,14 @@ If our subscription were in pending state, nothing would happen:
   >>> interfaces.IMessageAssemble(channel)(request)
   0
   >>> subscription.metadata['pending'] = False
+
+If the user has unsubscribed, nothing would happen either:
+
+  >>> subscription.metadata['unsubscribed'] = '2018-06-11'
+  >>> interfaces.IMessageAssemble(channel)(request)
+  0
+  >>> subscription.metadata['unsubscribed'] = None
+
 
 If our subscription were for a format that's unknown, an error is
 raised:
@@ -229,7 +237,7 @@ for our ``my-format`` composer to render both strings and Subscription
 objects to unicode:
 
   >>> from zope.publisher.interfaces.browser import IBrowserRequest
-  
+
   >>> component.provideAdapter(scheduler.UnicodeFormatter,
   ...                          adapts=(str, IBrowserRequest))
   >>> component.provideAdapter(scheduler.UnicodeFormatter,
@@ -263,12 +271,12 @@ out:
   >>> class Grappa4LifeTransform(object):
   ...     interface.implements(interfaces.ITransform)
   ...     component.adapts(str)
-  ... 
+  ...
   ...     sub = u'life'
   ...     stitute = u'Grappa'
   ...     def __init__(self, context):
   ...         self.context = context
-  ... 
+  ...
   ...     def __call__(self, text, subscription):
   ...         return text.replace(self.sub, self.stitute)
 
@@ -307,7 +315,7 @@ We can supply our own items to assemble_messages:
   1
 
 ... and choose not to include the collector items:
-  
+
   >>> interfaces.IMessageAssemble(channel)(request, items, use_collector=False)
   Rendering message with (u'Vincenzo', u'likes', u'Grappa', u'and', u'singing') for <Subscription 'daniel'>
   1


### PR DESCRIPTION
* unsubscribed subscriptions are replaced when adding a new one with the
same key
* they are omitted when sending out mails (as are pending subscriptions)

(refs https://github.com/collective/collective.dancing/issues/15)